### PR TITLE
fix: set_output warning message

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Example:
 steps:
 - name: Get token
   id: get_token
-  uses: machine-learning-apps/actions-app-token@master
+  uses: mentalmonkeysoftware/actions-app-token@master
   with:
     APP_PEM: ${{ secrets.APP_PEM }}
     APP_ID: ${{ secrets.APP_ID }}

--- a/action.yml
+++ b/action.yml
@@ -16,4 +16,4 @@ branding:
   icon: 'unlock'
 runs:
   using: 'docker'
-  image: 'docker://hamelsmu/app-token'
+  image: 'docker://mentalmonkeysoftware/app-token'


### PR DESCRIPTION
## Description 
Github has started issuing warnings around the imminent depreciation of `set_output`, which the original library uses.

To ensure continuation of functionality, this has been updated to use the preferred `GITHUB_OUTPUT` mechanism.
